### PR TITLE
Remove warnings capturing to allow execution to continue

### DIFF
--- a/scripts/imputation_cron_job.R
+++ b/scripts/imputation_cron_job.R
@@ -126,7 +126,4 @@ tryCatch({
   write_logs(LOGS, message)
   send_email(message = paste(message, "Server will retry imputation."))
   single_imputation_run(uniqueID, rawdata)
-}, warning = function(warning_message) {
-  write_logs(LOGS, paste("The imputation process finished with warnings:", warning_message, "ID:", uniqueID))
-  return(TRUE)
 })


### PR DESCRIPTION
Removed warning capture from imputation process to allow execution to continue.